### PR TITLE
fix: Restore ProcessTimeoutException under Guzzle 8

### DIFF
--- a/src/DockerClient.php
+++ b/src/DockerClient.php
@@ -57,8 +57,20 @@ final class DockerClient
         } catch (ClientException $e) {
             throw new BadRequestException($this->describeError($e), $e->getCode(), $e);
         } catch (GuzzleException $e) {
+            if ($this->isTimeout($e)) {
+                throw new ConnectionException("Could not connect to the Docker daemon: {$e->getMessage()}", 0, $e);
+            }
+
             throw new DockerException("Docker API request failed: {$e->getMessage()}", 0, $e);
         }
+    }
+
+    private function isTimeout(GuzzleException $e): bool
+    {
+        $message = $e->getMessage();
+
+        return str_contains($message, 'timed out')
+            || str_contains($message, 'cURL error 28');
     }
 
     /**


### PR DESCRIPTION
Guzzle 8 surfaces read/response timeouts as a TransferException (e.g. ResponseTimeoutException) instead of a ConnectException, so the timeout fell through to the generic GuzzleException catch and became a plain DockerException. Container::wait() never saw a ConnectionException and so never raised ProcessTimeoutException, breaking the timeout test.

Detect the timeout message in the GuzzleException branch and route it through ConnectionException, which wait() already converts.